### PR TITLE
Make port configurable via IPP_PORT

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -146,6 +146,7 @@ app.get('*', (req, res) => {
 })
 
 // Start the ExpressJS server
-app.listen(3000, () => {
-  console.log(dayjs().format() + ' Server started')
+const port = process.env.IPP_PORT || 3000;
+app.listen(port, () => {
+  console.log(dayjs().format() + ' Server started on port ' + port)
 })


### PR DESCRIPTION
Simple change to make the port configurable when not running in a container. Part of the changes for NixOS packaging: #34

```
$ npm run build

> immich-public-proxy@1.5.3 build
> npx tsc

$ npm run start

> immich-public-proxy@1.5.3 start
> node dist/index.js

2024-12-02T09:31:15-08:00 Server started on port 3000
^C
$ IPP_PORT=9000 npm run start

> immich-public-proxy@1.5.3 start
> node dist/index.js

2024-12-02T09:31:23-08:00 Server started on port 9000
^C
```