### PR TITLE
Add bin to package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/alangrainger/immich-public-proxy.git"
   },
   "main": "dist/index.js",
+  "bin": "dist/index.js",
   "dependencies": {
     "archiver": "^7.0.1",
     "dayjs": "^1.11.13",

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import express from 'express'
 import immich from './immich'
 import render from './render'


### PR DESCRIPTION
Add a `bin` property to `package.json`, allowing the proxy to be built as an executable script. For current use cases, this should be a no-op, since it only applies when IPP is installed globally or as a dependency ([npm docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin)).

Part of the changes for NixOS packaging: https://github.com/alangrainger/immich-public-proxy/discussions/34