### PR TITLE
Enable locating config.json at IPP_CONFIG

### DIFF
--- a/app/src/functions.ts
+++ b/app/src/functions.ts
@@ -3,7 +3,7 @@ import { Response } from 'express-serve-static-core'
 
 let config = {}
 try {
-  const configJson = require('../config.json')
+  const configJson = require(process.env.IPP_CONFIG || '../config.json')
   if (typeof configJson === 'object') config = configJson
 } catch (e) { }
 


### PR DESCRIPTION
One more change from the NixOS packaging: the config file is hard-coded at `../config.json`, which relies on some assumptions about the exact location of `config.json` relative to the proxy's working directory. This change allows using the envvar `IPP_CONFIG` to point to a config file anywhere:

```
~/projects/immich-public-proxy/app $ jq -n '{ ipp: { responseHeaders: { "x-hello": "world"} } }' > /tmp/config.json
~/projects/immich-public-proxy/app $ IPP_CONFIG=/tmp/config.json npm run start

> immich-public-proxy@1.5.3 start
> node dist/index.js

2024-12-10T23:34:40-08:00 Server started on port 3000
^Z
[1]+  Stopped                 IPP_CONFIG=/tmp/config.json npm run start
~/projects/immich-public-proxy/app $ bg
[1]+ IPP_CONFIG=/tmp/config.json npm run start &
~/projects/immich-public-proxy/app $ curl -sD - -o /dev/null localhost:3000
HTTP/1.1 200 OK
X-Powered-By: Express
x-hello: world
Content-Type: text/html; charset=utf-8
Content-Length: 764
ETag: W/"2fc-Xjpot18CCIhr5kgTKcWGa8EC+ZM"
Date: Wed, 11 Dec 2024 07:35:08 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```