### PR TITLE
chore: Typescript as `devDependency`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 /app/node_modules/
 /app/dist/
 /app/.env
-/app/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine AS builder
 
 USER node
 WORKDIR /app
-COPY -chown=node:node app/ ./
+COPY --chown=node:node app/ ./
 
 RUN npm ci \
     && npx tsc 
@@ -13,7 +13,7 @@ RUN apk --no-cache add curl
 
 USER node
 WORKDIR /app
-COPY --chown=node:node app/ ./
+COPY --from=builder --chown=node:node app/ ./
 
 RUN npm ci --omit=dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine as builder
+FROM node:lts-alpine AS builder
 
 USER node
 WORKDIR /app
@@ -7,14 +7,15 @@ COPY -chown=node:node app/ ./
 RUN npm ci \
     && npx tsc 
 
-FROM node:lts-alpine as runner
+FROM node:lts-alpine AS runner
+
+RUN apk --no-cache add curl 
 
 USER node
 WORKDIR /app
 COPY --chown=node:node app/ ./
 
-RUN apk --no-cache add curl \
-    && npm ci --omit=dev
+RUN npm ci --omit=dev
 
 ARG PACKAGE_VERSION
 ENV APP_VERSION=${PACKAGE_VERSION}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,8 +15,7 @@
         "dotenv": "^16.4.5",
         "ejs": "^3.1.10",
         "express": "^4.21.1",
-        "tslib": "^2.8.1",
-        "typescript": "^5.6.2"
+        "tslib": "^2.8.1"
       },
       "bin": {
         "immich-public-proxy": "dist/index.js"
@@ -30,7 +29,8 @@
         "@typescript-eslint/parser": "5.29.0",
         "eslint": "^8.49.0",
         "eslint-config-standard": "^17.1.0",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.2"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -5182,6 +5182,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/app/package.json
+++ b/app/package.json
@@ -23,8 +23,7 @@
     "dotenv": "^16.4.5",
     "ejs": "^3.1.10",
     "express": "^4.21.1",
-    "tslib": "^2.8.1",
-    "typescript": "^5.6.2"
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.3",
@@ -35,6 +34,7 @@
     "@typescript-eslint/parser": "5.29.0",
     "eslint": "^8.49.0",
     "eslint-config-standard": "^17.1.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.2"
   }
 }


### PR DESCRIPTION
Very surface level, but when reading through the repo this was the first thing that jumped out at me.

Reduces `node_modules` size by half in the built image
Before: 
```bash
$ du -hc -d 0 node_modules/
43.7M	node_modules/
```

After:
```bash
$ du -hc -d 0 node_modules/
21.1M	node_modules/
21.1M	total
```