### PR TITLE
Pull request for #117

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM node:lts-alpine AS builder
 
+# Maak de map aan en stel juiste rechten in
+RUN mkdir /app && chown node:node /app
+
 USER node
 WORKDIR /app
 COPY --chown=node:node app/ ./
+
+# Zorg dat node_modules map er is en van node is
+RUN mkdir -p node_modules && npm ci && npx tsc
 
 RUN npm ci \
     && npx tsc 

--- a/app/public/web.js
+++ b/app/public/web.js
@@ -33,6 +33,16 @@ class LGallery {
     }, params.lgConfig))
     this.items = params.items
 
+    // If openItem is provided, open the corresponding image (1-based index)
+    if (typeof params.openItem !== 'undefined' && params.openItem > 0) {
+      setTimeout(() => {
+        const thumbs = document.querySelectorAll('#lightgallery a')
+        if (thumbs.length >= params.openItem) {
+          thumbs[params.openItem - 1].click()
+        }
+      }, 0)
+    }
+
     let timeout
     window.addEventListener('scroll', () => {
       if (timeout) clearTimeout(timeout)

--- a/app/src/immich.ts
+++ b/app/src/immich.ts
@@ -135,7 +135,12 @@ class Immich {
     } else {
       // Multiple images - render as a gallery
       log('Serving link ' + request.key)
-      await render.gallery(res, link)
+      let openItem: number | undefined = undefined
+      if (request.asset) {
+        const idx = link.assets.findIndex(a => a.id === request.asset)
+        if (idx !== -1) openItem = idx + 1 // openItem is 1-based
+      }
+      await render.gallery(res, link, openItem)
     }
   }
 

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -75,12 +75,14 @@ app.get(/^(|\/share)\/healthcheck$/, async (_req, res) => {
  * [ROUTE] This is the main URL that someone would visit if they are opening a shared link
  */
 app.get('/:shareType(share|s)/:key/:mode(download)?', decodeCookie, async (req, res) => {
+  // Accept ?asset=ID for deep-linking to a specific asset in the gallery
   await immich.handleShareRequest({
     req,
     key: req.params.key,
     keyType: req.params.shareType === 's' ? KeyType.slug : KeyType.key,
     mode: req.params.mode,
-    password: req.password
+    password: req.password,
+    asset: req.query.asset as string | undefined // <-- new
   }, res)
 })
 

--- a/app/src/render.ts
+++ b/app/src/render.ts
@@ -84,7 +84,7 @@ class Render {
    *
    * @param res - ExpressJS Response
    * @param share - Immich `shared-link` containing the assets to show in the gallery
-   * @param [openItem] - Immediately open a lightbox to the Nth item when the gallery loads
+   * @param [openItem] - Immediately open a lightbox to the Nth item when the gallery loads (1-based index)
    */
   async gallery (res: Response, share: SharedLink, openItem?: number) {
     const items = []
@@ -136,7 +136,7 @@ class Render {
     }
     res.render('gallery', {
       items,
-      openItem,
+      openItem, // 1-based index for initial open item
       title: this.title(share),
       publicBaseUrl,
       path: '/share/' + share.key,

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -68,8 +68,9 @@ export interface IncomingShareRequest {
   req: Request;
   key: string;
   keyType?: KeyType;
-  password?: string;
   mode?: string;
+  password?: string;
+  asset?: string; // Optional asset ID for deep-linking
   size?: ImageSize;
   range?: string;
 }

--- a/app/views/gallery.ejs
+++ b/app/views/gallery.ejs
@@ -48,7 +48,7 @@
       items,
       openItem
   }) %>) // initLightGallery imported from web.js
-  <% if (openItem) { %>
+  <% if (typeof openItem !== 'undefined') { %>
   const openItem = <%- openItem %>
   const thumbs = document.querySelectorAll('#lightgallery a')
   if (thumbs.length >= openItem) {


### PR DESCRIPTION
I tried to fix [#117](https://github.com/alangrainger/immich-public-proxy/discussions/117) myself. 

The solution allows for an additional ?asset=<assetID> e.g.
https://image.pgorissen.com/share/iv-87puxrwU1QCht0pqA--q8BSAmGV2wjXU62Co6qne1Y5oteH7RQ7mRvfyUqOxElyI?asset=74e67be7-a652-4751-a1ae-c2af3723439c
This then automatically opens the multi image gallery on this image. Any of the available images in the gallery can be used.
<img width="1645" height="924" alt="image" src="https://github.com/user-attachments/assets/a2dfbf30-ee85-46a2-83b4-742e0879b307" />
If no assetID is provided, the regular view is used.

I also had to make some changes to Dockerfile because of errors during the rebuild.

(sorry for adding both in one pull request, am really new to this.)
