### PR TITLE
docs: add mTLS configuration for Traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To view a shared album in Immich, you need access to the `/api/` path. If you're
 to make that path public. Any existing or future vulnerability has the potential to compromise your Immich instance.
 
 For me, the ideal setup is to have Immich secured privately behind mTLS or VPN, and only allow public access to Immich Public Proxy.
-Here is an example setup for [securing Immich behind mTLS](./docs/securing-immich-with-mtls.md) using Caddy.
+Here is an example setup for [securing Immich behind mTLS](./docs/securing-immich-with-mtls.md) using a reverse proxy such as Caddy or Traefik.
 
 ## Installation
 

--- a/docs/securing-immich-with-mtls.md
+++ b/docs/securing-immich-with-mtls.md
@@ -1,35 +1,16 @@
-# Securing Immich with mTLS using Caddy
+# Securing Immich with mTLS using a reverse proxy
 
 Immich supports using a custom client certificate on both web and mobile apps, so it's one of the easiest and safest ways to limit access to only clients of your choice.
 
-## Caddy docker-compose.yml
-
-```yaml
-version: "3.7"
-
-services:
-  caddy:
-    image: caddy:2
-    restart: unless-stopped
-    cap_add:
-      - NET_ADMIN
-    ports:
-      - "6443:443"
-      - "6443:443/udp"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:Z
-      - ./site:/srv:Z
-      - ./data:/data:Z
-      - ./config:/config:Z
-```
-
 ## Authenticating with mutual TLS
+
+The process of generating the certificates is the same regardless of which reverse proxy you use. Just make sure to place the folder "certs/" under a volume that is mounted to your reverse proxy container.
 
 ### Generate your client certificate
 
 This is a basic way to generate a certificate for a user. If it's only you using your own homelab, then you'll just need to make one certificate.
 
-This certificate will last for ~10 years (although of course you can revoke it at any time by deleting it from Caddy's key store).
+This certificate will last for ~10 years (although of course you can revoke it at any time by deleting it from your reverse proxy key store).
 
 ```bash
 #!/bin/bash
@@ -57,7 +38,26 @@ openssl pkcs12 -export -out certs/client.pfx -inkey certs/client.key -in certs/c
 rm certs/client.req
 ```
 
-## Configure Caddyfile
+## Using Caddy
+### Caddy docker-compose.yaml
+
+```yaml
+services:
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "6443:443"
+      - "6443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:Z
+      - ./site:/srv:Z
+      - ./data:/data:Z
+      - ./config:/config:Z
+```
+### Configure Caddyfile
 
 ```Caddyfile
 https://immich.mydomain.com {
@@ -69,4 +69,56 @@ https://immich.mydomain.com {
     }
     reverse_proxy internal_server.lan:2283
 }
+```
+
+## Using Traefik
+### Traefik docker-compose.yaml
+```yaml
+services:
+  traefik:
+    image: traefik:3.5
+    container_name: traefik
+    hostname: traefik
+    restart: always
+    environment:
+      - TZ=Europe/Madrid
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./config:/etc/traefik
+```
+
+### Configure Traefik dynamic file:
+```yaml
+http:
+  services:
+    immich:
+      loadBalancer:
+        servers:
+          - url: "http://immich:2283"
+
+  routers:
+    immich:
+      entryPoints:
+        - websecure
+      service: immich
+      rule: "Host(`immich.mydomain.com`)"
+      tls:
+        certResolver: letsencrypt
+        options: mtlsOptions
+
+tls:
+  options:
+    mtlsOptions:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      clientAuth:
+        caFiles:
+          - /etc/traefik/certs/client.crt
+        clientAuthType: RequireAndVerifyClientCert
 ```


### PR DESCRIPTION
Hi there!

First of all, thanks for developing this solution, it's just great. I started using it and limiting Immich to only lan network, but I wanted to use mTLS as well, but my reverse proxy is Traefik. I found a incredibly lack of official documentation in Traefik docs, and the tutorials I saw online wasn't just as easy as yours and others for Caddy. 

So I simply adapted yours to Traefik, and I took the liberty of adding the steps on how to integrate mTLS into Traefik and adapt the documentation, in order to help users like me that use other reverse proxies. Hope that this is not a problem for you, feel free to make any modifications you'd like or even discard it if it is out of scope.

Many thanks again!