### PR TITLE
Docker image metadata with OCI annotations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract Docker image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ github.repository }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -56,3 +62,4 @@ jobs:
             ${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ env.PACKAGE_VERSION }}
             ghcr.io/${{ github.repository }}:latest
+          annotations: ${{ steps.metadata.output.annotations }}


### PR DESCRIPTION
[OCI image annotations](https://docs.docker.com/build/metadata/annotations/) add metadata to container images. My personal use case would be to allow the [Renovate bot](https://docs.renovatebot.com/) to fetch release notes from Github when updating the IPP version in `docker-compose.yml` (like it already does with the main Immich version), but this may also be useful for other container admin tools.

My initial implementation used manual `LABEL`s in the Dockerfile (https://github.com/esammier/immich-public-proxy/tree/feat-oci-annotations), before I found out from the [Docker docs](https://docs.docker.com/build/ci/github-actions/annotations/) that they have a Github Action [`docker/metadata-action`](https://github.com/docker/metadata-action/tree/releases/v4) that does it automatically. I couldn't test this one yet since I need to set up Github CI on my fork with new tokens etc... but feel free to use the manual branch if you prefer. 