### PR TITLE
Implementation of Feature #167; loading more items in carousel mode

### DIFF
--- a/app/public/web.js
+++ b/app/public/web.js
@@ -39,6 +39,13 @@ class LGallery {
       timeout = setTimeout(lgallery.handleScroll, 100)
     })
     lgallery.handleScroll()
+
+    const preloadThreshold = 8
+    this.element.addEventListener('lgAfterSlide', (event) => {
+      if (event.detail.index >= this.index - preloadThreshold) {
+        lgallery.loadMoreItems();
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
As described in the feature request #167 , the infinite scrolling works great to load the elements on scroll, but the same is not done in carousel mode. This PR intends to do that.

The idea is to listen to lightGallery slide events, specifically to the [lgAfterSlide](https://www.lightgalleryjs.com/docs/events/#lgAfterSlide) which is fired immediately after each slide transition.
And if we are reaching the current index or elements call the same `loadMoreItems` function as the scroll listener does.

As a result when getting close to the final elements, more elements are loaded in