### PR TITLE
Switch to LightGallery dynamic mode

### DIFF
--- a/app/public/web.js
+++ b/app/public/web.js
@@ -20,7 +20,7 @@ class LGallery {
       This license key was graciously provided by LightGallery under their
       GPLv3 open-source project license:
       */
-      licenseKey: '8FFA6495-676C4D30-8BFC54B6-4D0A6CEC'
+      licenseKey: '8FFA6495-676C4D30-8BFC54B6-4D0A6CEC',
       /*
       Please do not take it and use it for other projects, as it was provided
       specifically for Immich Public Proxy.
@@ -30,6 +30,8 @@ class LGallery {
 
       https://www.lightgalleryjs.com/docs/settings/#licenseKey
       */
+      dynamic: true,
+      dynamicEl: params.items.slice(0, PER_PAGE).map((item) => item.dynamicEl),
     }, params.lgConfig))
     this.items = params.items
 
@@ -67,7 +69,7 @@ class LGallery {
           this.element.insertAdjacentHTML('beforeend', item.html + '\n')
         })
       this.index += PER_PAGE
-      this.lightGallery.refresh()
+      this.lightGallery.refresh(this.items.slice(0, this.index).map((item) => item.dynamicEl))
     } else {
       // Remove the loading spinner once all items are loaded
       document.getElementById('loading-spinner')?.remove()
@@ -75,3 +77,8 @@ class LGallery {
   }
 }
 const lgallery = new LGallery()
+
+function openGallery(event, index) {
+  event.preventDefault() // don't open the <a href=""> image link
+  lgallery.lightGallery.openGallery(index)
+}

--- a/app/src/render.ts
+++ b/app/src/render.ts
@@ -110,7 +110,7 @@ class Render {
     const publicBaseUrl = process.env.PUBLIC_BASE_URL || res.req.headers.publicBaseUrl || (res.req.protocol + '://' + res.req.headers.host)
 
     // Use .map to generate an array of promises, then await them all to load in parallel.
-    const items = await Promise.all(share.assets.map(async (asset) => {
+    const items = await Promise.all(share.assets.map(async (asset, index) => {
       let video, downloadUrl
       if (asset.type === AssetType.video) {
         // Populate the data-video property
@@ -139,6 +139,7 @@ class Render {
       // Create the full HTML element source to pass to the gallery view
       const itemHtml = [
         video ? `<a data-video='${video}'` : `<a href="${previewUrl}"`,
+        ` onClick="openGallery(event, ${index})"`,
         downloadUrl ? ` data-download-url="${downloadUrl}"` : '',
         description ? ` data-sub-html='<p>${description}</p>'` : '',
         ` data-download="${this.getFilename(asset)}"><img alt="" src="${thumbnailUrl}"/>`,
@@ -149,7 +150,15 @@ class Render {
       return {
         html: itemHtml,
         thumbnailUrl,
-        previewUrl
+        previewUrl,
+        dynamicEl: {
+          src: video ? undefined : previewUrl,
+          thumb: thumbnailUrl,
+          subHtml: description ? `<p>${description}</p>` : '',
+          downloadUrl: downloadUrl ?? false,
+          video: video,
+          alt: thumbnailUrl
+        }
       }
     }))
 


### PR DESCRIPTION
Intended to fix #169. While `this.lightGallery.refresh` calls were taking more and more time for each new page in 'static mode' the same issue is not present in 'dynamic mode'.

As a result this PR changes lightGallery's mode to dynamic:
- the HTML tags for the overview are added manually
- the lightGallery is initalized with dynamic and dynamicEl variables
- refresh calls get a new list

This way even when the 31st page is loaded, it feels just as snappy as the 1st.