### PR TITLE
fixes #176 and re-enable #174

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -124,18 +124,12 @@ app.get('/share/:type(photo|video)/:key/:id/:size?', decodeCookie, async (req, r
     respondToInvalidRequest(res, 404, 'Invalid size parameter ' + req.path)
     return
   }
-
-  /*
-  This was the change made in PR https://github.com/alangrainger/immich-public-proxy/pull/174
-  I have had to remove this because it was preventing password-protected slug albums
-  from working.
-
-  This will be added back in once the slug issue is solved.
-
+  
   // Validate share link and check password before serving assets
   // This prevents direct URL access from bypassing password protection
   // The password is provided from the encrypted session cookie (if set)
-  const share = await immich.getShareByKey(req.params.key, req.password)
+  const keyType = immich.getKeyTypeFromShare(req.params.shareType)
+  const share = await immich.getShareByKey(req.params.key, req.password, keyType)
   if (!share) {
     respondToInvalidRequest(res, 404, 'Invalid share link')
     return
@@ -153,7 +147,6 @@ app.get('/share/:type(photo|video)/:key/:id/:size?', decodeCookie, async (req, r
     respondToInvalidRequest(res, 404, 'Asset not found in share')
     return
   }
-  */
 
   const request = {
     req,


### PR DESCRIPTION
~~#174 didn't check for the KeyType, which resulted in broken slug links (#176). This passes the right KeyType allowing slugs to work again.~~

worked due to wrongly configured cache during testing, not actually a solution to both issues.