### PR TITLE
fix: pass actual dimensions to lightGallery for proper video framing

### DIFF
--- a/app/src/render.ts
+++ b/app/src/render.ts
@@ -135,10 +135,13 @@ class Render {
       const thumbnailUrl = immich.photoUrl(share.key, asset.id, ImageSize.thumbnail)
       const previewUrl = immich.photoUrl(share.key, asset.id, immich.getPreviewImageSize(asset))
       const description = getConfigOption('ipp.showMetadata.description', false) && typeof asset?.exifInfo?.description === 'string' ? asset.exifInfo.description.replace(/'/g, '&apos;') : ''
+      const assetWidth = asset.width || asset.exifInfo?.exifImageWidth
+      const assetHeight = asset.height || asset.exifInfo?.exifImageHeight
 
       // Create the full HTML element source to pass to the gallery view
       const itemHtml = [
         video ? `<a data-video='${video}'` : `<a href="${previewUrl}"`,
+        assetWidth && assetHeight ? ` data-lg-size="${assetWidth}-${assetHeight}"` : '',
         downloadUrl ? ` data-download-url="${downloadUrl}"` : '',
         description ? ` data-sub-html='<p>${description}</p>'` : '',
         ` data-download="${this.getFilename(asset)}" data-slide-name="${asset.id}"><img alt="" src="${thumbnailUrl}"/>`,

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -12,6 +12,8 @@ export enum KeyType {
 
 export interface ExifInfo {
   description?: string;
+  exifImageWidth?: number;
+  exifImageHeight?: number;
 }
 
 export enum AlbumType {
@@ -30,6 +32,8 @@ export interface Asset {
   type: AssetType;
   isTrashed: boolean;
   exifInfo?: ExifInfo;
+  width?: number;
+  height?: number;
 }
 
 export interface Album {


### PR DESCRIPTION
Videos were displaying with incorrect aspect ratios due to fixed dimensions. This change passes actual video and image dimensions to lightGallery via data-lg-size, allowing proper layout and framing.

before:
<img width="1052" height="1242" alt="Screenshot 2026-02-03 at 1 56 07 PM" src="https://github.com/user-attachments/assets/3df16f55-4091-49ab-8d88-d6a39299f6da" />

after:
<img width="1052" height="1241" alt="Screenshot 2026-02-03 at 1 57 00 PM" src="https://github.com/user-attachments/assets/811c1fa1-15f5-40f0-82c3-7716dea7dd94" />
