### PR TITLE
Fix numerous XSS vulnerabilities when rendering text coming from the Immich instance

### DIFF
--- a/app/src/render.ts
+++ b/app/src/render.ts
@@ -6,6 +6,15 @@ import archiver from 'archiver'
 import { respondToInvalidRequest } from './invalidRequestHandler'
 import { sanitize } from './includes/sanitize'
 
+function escapeHtml (str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
 class Render {
   lgConfig
 
@@ -134,7 +143,7 @@ class Render {
 
       const thumbnailUrl = immich.photoUrl(share.key, asset.id, ImageSize.thumbnail)
       const previewUrl = immich.photoUrl(share.key, asset.id, immich.getPreviewImageSize(asset))
-      const description = getConfigOption('ipp.showMetadata.description', false) && typeof asset?.exifInfo?.description === 'string' ? asset.exifInfo.description.replace(/'/g, '&apos;') : ''
+      const description = getConfigOption('ipp.showMetadata.description', false) && typeof asset?.exifInfo?.description === 'string' ? escapeHtml(asset.exifInfo.description) : ''
 
       // Create the full HTML element source to pass to the gallery view
       const itemHtml = [

--- a/app/views/gallery.ejs
+++ b/app/views/gallery.ejs
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title><%- title %></title>
+    <title><%= title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <%
     // Add an og-image using the first image's thumbnail
     if (items?.[0]?.previewUrl) {
     %>
-        <meta property="og:title" content="<%- title %>">
+        <meta property="og:title" content="<%= title %>">
         <meta property="og:image" content="<%- publicBaseUrl %><%- items[0].previewUrl %>">
-        <meta name="twitter:title" content="<%- title %>">
+        <meta name="twitter:title" content="<%= title %>">
         <meta name="twitter:image" content="<%- publicBaseUrl %><%- items[0].previewUrl %>">
         <meta name="twitter:card" content="summary_large_image">
     <% } %>
@@ -20,7 +20,7 @@
 <body>
 <div id="header">
     <% if (showTitle) { %>
-        <h1><%- title || 'Gallery' %></h1>
+        <h1><%= title || 'Gallery' %></h1>
     <% } %>
     <%
     if (showDownload) {


### PR DESCRIPTION
This fixes few XSS vulnerabilities present when the proxy is rendering text - album name, descriptions - coming from the Immich instance.

This could allow users who can create albums or edit media descriptions in the Immich instance to execute arbitrary JS on the proxy domain. Since in most deployments the Immich instance and its users can be trusted, the impact is limited - only a self-XSS most of the time.

Because of the limited impact we feel comfortable reporting and directly fixing this way.

However, we recommend setting up a security policy (SECURITY.md) for possible future reports.

PoC:
1. Set the album name to `</title><body><script>alert('AISafe')</script>` in Immich and share this album.
2. Access the album via proxy.

We found this vulnerability with our autonomous security auditor [AISafe](https://aisafe.io/)