### PR TITLE
Show description in OpenGraph link previews

### DIFF
--- a/app/views/gallery.ejs
+++ b/app/views/gallery.ejs
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title><%= title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <%# Meta tags for link previews (title, optionally description and thumbnail) %>
+    <title><%= title %></title>
+    <meta property="og:title" content="<%= title %>">
+    <meta name="twitter:title" content="<%= title %>">
     <% if (description) { %>
         <meta name="description" content="<%= description %>">
         <meta property="og:description" content="<%= description %>">
@@ -12,9 +15,7 @@
     // Add an og-image using the first image's thumbnail
     if (items?.[0]?.previewUrl) {
     %>
-        <meta property="og:title" content="<%= title %>">
         <meta property="og:image" content="<%- publicBaseUrl %><%- items[0].previewUrl %>">
-        <meta name="twitter:title" content="<%= title %>">
         <meta name="twitter:image" content="<%- publicBaseUrl %><%- items[0].previewUrl %>">
         <meta name="twitter:card" content="summary_large_image">
     <% } %>

--- a/app/views/gallery.ejs
+++ b/app/views/gallery.ejs
@@ -3,6 +3,11 @@
 <head>
     <title><%= title %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <% if (description) { %>
+        <meta name="description" content="<%= description %>">
+        <meta property="og:description" content="<%= description %>">
+        <meta property="twitter:description" content="<%= description %>">
+    <% } %>
     <%
     // Add an og-image using the first image's thumbnail
     if (items?.[0]?.previewUrl) {


### PR DESCRIPTION
I was so glad to see #97 land in 1.15.2 that I just assumed it was for link previews too, and spent a few minutes restarting my containers wondering what I had done wrong... so I thought, might as well add it!

This adds all 3 meta tags I could find ([`name="description"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name#description) + the OG and Twitter flavors) when the share has a description.
The 2nd commit also rearranges the `title` meta tags, since I'm not sure why it would depend on the image `previewUrl` being set, but let me know if I'm mistaken.

Thanks for the great work!