### PR TITLE
fix: handle password-protected shares with Immich v2.6+

### DIFF
--- a/app/src/immich.ts
+++ b/app/src/immich.ts
@@ -200,8 +200,8 @@ class Immich {
               link
             }
           }
-        } else if (res.status === 401 && jsonBody?.message === 'Invalid password') {
-          // Password authentication required
+        } else if (res.status === 401) {
+          // Password authentication required (handles both "Invalid password" and "Password required" from Immich API)
           return {
             valid: true,
             passwordRequired: true


### PR DESCRIPTION
## Summary

- Immich v2.6 changed the API response for password-protected shared links from `"Invalid password"` to `"Password required"` when no password token is provided on `GET /api/shared-links/me`.
- The previous string match (`jsonBody?.message === 'Invalid password'`) caused the proxy to fall through to the catch-all and return 404 instead of rendering the password entry page.
- This fix matches on the `401` status code alone, since this endpoint only returns 401 for password-related reasons. This is backwards compatible with older Immich versions and resilient to future message wording changes.

Fixes #198

## Test plan

- [x] Tested with Immich v2.6.1 and a password-protected shared album
- [x] Proxy correctly shows the password entry page on first visit
- [x] Proxy correctly shows "invalid password" when a wrong password is submitted
- [x] Non-password-protected shares continue to work as before

Made with [Cursor](https://cursor.com)