### PR TITLE
fix: invalid share keys being treated as password-protected shares

### DIFF
--- a/app/src/immich.ts
+++ b/app/src/immich.ts
@@ -201,13 +201,18 @@ class Immich {
             }
           }
         } else if (res.status === 401) {
-          // Password authentication required (handles both "Invalid password" and "Password required" from Immich API)
-          return {
-            valid: true,
-            passwordRequired: true
+          // Immich returns 401 for both invalid keys and password-protected shares.
+          // Check the message to distinguish between the two cases.
+          if (jsonBody?.message === 'Invalid share key' || jsonBody?.message === 'Invalid share slug') {
+            // Known invalid key/slug - treat as invalid request
+            log('Invalid share key ' + key)
+          } else {
+            // Default: treat as password required (fail-safe)
+            return {
+              valid: true,
+              passwordRequired: true
+            }
           }
-        } else if (jsonBody?.message === 'Invalid share key') {
-          log('Invalid share key ' + key)
         } else {
           console.log(JSON.stringify(jsonBody))
         }


### PR DESCRIPTION
### Issue
When visiting a non-existent or deleted share URL (e.g. `/share/randomkey`), the proxy shows the password entry page instead of returning a 404 or respecting the `customInvalidResponse` configuration.

This happens because Immich returns HTTP 401 for both invalid share keys (`"Invalid share key"`) and password-protected shares (`"Password required"`). Since [PR #199](https://github.com/alangrainger/immich-public-proxy/pull/199) broadened the 401 handling from matching a specific message to matching the status code alone, all 401 responses - including invalid keys - are now treated as password-protected shares.

The previous PR's assumption that "this endpoint only returns 401 for password-related reasons" is incorrect. Immich's `validateSharedLinkKey` in `auth.service.ts` throws `UnauthorizedException('Invalid share key')` (HTTP 401) when a key does not exist in the database.

Fixes [#202](https://github.com/alangrainger/immich-public-proxy/issues/202)

### Fix
This PR checks the response `message` field within the 401 branch to distinguish invalid keys from password-protected shares.

### Why this approach?
- Known invalid messages (`"Invalid share key"`, `"Invalid share slug"`) are explicitly rejected and fall through to `{ valid: false }`, which triggers respondToInvalidRequest - correctly respecting the `customInvalidResponse` config.
- All other 401 responses default to `{ valid: true, passwordRequired: true }`, preserving the password page behavior. This is a fail-safe default; if Immich changes or adds new 401 messages in the future, password-protected shares will continue to work rather than silently breaking.
- This is backwards compatible with older Immich versions and the Immich v2.6 message change that prompted the previous PR.

Tested the fix on my own Immich-public-proxy instance that is running behind Cloudflare with both invalid share keys and password-protected albums.