### PR TITLE
Fix: enable seamless next page loading during lightGallery sliding (Adapts #168)

### DIFF
--- a/app/public/web.js
+++ b/app/public/web.js
@@ -16,6 +16,7 @@ class LGallery {
     this.lightGallery = lightGallery(this.element, Object.assign({
       plugins: [lgZoom, lgThumbnail, lgVideo, lgFullscreen, lgHash],
       speed: 500,
+      loop: params.items.length <= PER_PAGE,
       /*
       This license key was graciously provided by LightGallery under their
       GPLv3 open-source project license:
@@ -34,14 +35,23 @@ class LGallery {
     this.items = params.items
 
     const spinner = document.getElementById('loading-spinner')
+    let observer = null
+
     if (spinner) {
-      const observer = new IntersectionObserver((entries) => {
+      observer = new IntersectionObserver((entries) => {
         if (entries[0].isIntersecting) {
           lgallery.loadMoreItems(observer, spinner)
         }
       }, { rootMargin: '200px' })
       observer.observe(spinner)
     }
+
+    const preloadThreshold = 8
+    this.element.addEventListener('lgAfterSlide', (event) => {
+      if (event.detail.index >= this.index - preloadThreshold) {
+        lgallery.loadMoreItems(observer, spinner)
+      }
+    })
   }
 
   /**
@@ -60,8 +70,8 @@ class LGallery {
       this.lightGallery.refresh()
     } else {
       // Remove the loading spinner and stop observing once all items are loaded
-      observer.disconnect()
-      spinner.remove()
+      if (observer) observer.disconnect()
+      if (spinner) spinner.remove()
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where `lightGallery` fails to load new elements when a user is actively swiping/sliding inside the fullscreen modal. Previously, users had to close the gallery, manually scroll the page down to trigger the next fetch, and reopen the gallery.

an example of what the problem was:
My album 150 elements.
After open shared link - i see first 100 elements on page. And i cant open lightGallery and sliding from 1 to 150

### Background & Credits
This is an updated and adapted version of the logic originally proposed by @fknives in PR #168. 
Since the base code recently migrated from scroll events to `IntersectionObserver`, PR #168 had merge conflicts. I adapted the logic to correctly pass the required `observer` and `spinner` objects.

### Specific Changes
1. **Event Listener (`lgAfterSlide`)**: Added a trigger with a `preloadThreshold = 8`. As the user approaches the end of the currently loaded images, it seamlessly calls `lgallery.loadMoreItems(observer, spinner)` in the background.
2. **Intelligent Loop**: Added a dynamic loop condition `loop: params.items.length <= PER_PAGE` to the gallery initialization. 
   - If an album is small (e.g., < 50 items), the gallery retains its looping feature.
   - If an album is large, `loop` is disabled to prevent the gallery from instantly snapping back to the first image before the next page has time to fetch over the network.