### PR TITLE
fix: use SameSite=Lax for session cookie

### DIFF
--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -28,7 +28,7 @@ const app = express()
 app.use(cookieSession({
   name: 'session',
   httpOnly: true,
-  sameSite: 'strict',
+  sameSite: 'lax',
   secret: crypto.randomBytes(32).toString('base64url')
 }))
 // For parsing the password unlock form and POSTed JSON payloads


### PR DESCRIPTION
Fixes #232 - Unable to unlock password protected link with cross-site context

This can be verified by opening a password protected link from, e.g. WhatsApp Web, Telegram Web, etc.