### PR TITLE
Fix PhotoSwipe lightbox configuration for better customization

### DIFF
--- a/app/public/photoswipe-overrides.css
+++ b/app/public/photoswipe-overrides.css
@@ -15,12 +15,6 @@
   --pswp-transition-duration: 250ms;
 }
 
-/* Hide UI Immich doesn't show */
-.pswp__button--zoom,
-.pswp__counter {
-  display: none !important;
-}
-
 /* Top toolbar: subtle dark backdrop, no shadows */
 .pswp__top-bar {
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent);
@@ -51,12 +45,7 @@
   color: var(--pswp-icon-color);
 }
 
-/* Hide PhotoSwipe's default top-right X close button - we use a top-left
-   back arrow instead (registered as `back-button` in client/lightbox-ui.ts),
-   matching Immich's native asset-viewer affordance. */
-.pswp__button--close {
-  display: none;
-}
+
 
 .pswp__button--download-button {
   color: #fff;

--- a/app/src/client/lightbox.ts
+++ b/app/src/client/lightbox.ts
@@ -100,7 +100,7 @@ export function initLightbox () {
     loop: false,
     counter: false,
     zoom: false,
-    close: true,
+    close: false,
     // paddingFn lets the sidebar shrink the slide viewport when open. On a
     // narrow viewport the sidebar overlays instead, so we leave padding
     // alone in that case.

--- a/app/src/client/lightbox.ts
+++ b/app/src/client/lightbox.ts
@@ -82,24 +82,35 @@ function buildDataSource () {
 export function initLightbox () {
   const { options = {} } = state.lightboxConfig
 
+  // Extract padding to use as defaults, and paddingFn to avoid overwriting our function with an object from JSON
+  const { padding, paddingFn: _ignoredPaddingFn, ...restOptions } = options as any
+
+  const basePadding = {
+    top: padding?.top ?? 56,
+    bottom: padding?.bottom ?? 56,
+    left: padding?.left ?? 16,
+    right: padding?.right ?? 16
+  }
+
   state.lightbox = new PhotoSwipeLightbox({
     bgOpacity: 1,
     showHideAnimationType: 'fade',
     closeOnVerticalDrag: true,
     arrowKeys: true,
     loop: false,
+    counter: false,
+    zoom: false,
+    close: true,
     // paddingFn lets the sidebar shrink the slide viewport when open. On a
     // narrow viewport the sidebar overlays instead, so we leave padding
     // alone in that case.
     paddingFn: () => ({
-      top: 56,
-      bottom: 56,
-      left: 16,
+      ...basePadding,
       right: state.sidebarOpen && window.innerWidth >= MOBILE_BREAKPOINT
-        ? SIDEBAR_WIDTH + 16
-        : 16
+        ? SIDEBAR_WIDTH + basePadding.right
+        : basePadding.right
     }),
-    ...options,
+    ...restOptions,
     dataSource: buildDataSource(),
     // @ts-expect-error - runtime URL resolved by Express static
     pswpModule: () => import('/share/static/photoswipe/photoswipe.esm.js') // eslint-disable-line import/no-absolute-path


### PR DESCRIPTION
Removes hardcoded CSS and JavaScript restrictions to allow customization of the PhotoSwipe lightbox via the configuration json file

### Changes made
* **Extracted padding configuration:** Updated `lightbox.ts` to read custom `padding` values from the config while still preserving the dynamic right-padding math needed for the sliding info sidebar. 
* **Prevented config crashes:** Configured `lightbox.ts` to gracefully ignore `paddingFn` object if accidentally passed from the JSON config, preventing application crashes. (because lightbox expects a function)
* **Removed hardcoded CSS hiding:** Removed CSS rules that forced `display: none` on `.pswp__button--zoom`, `.pswp__button--counter`, and `.pswp__button--close`.
* **Added JS fallback defaults:** Replaced the CSS hiding with default JavaScript configurations (`zoom: false`, `counter: false`, etc.) directly inside the PhotoSwipe initialization. 
### Benefits
Users now have complete control to enable or disable PhotoSwipe UI elements (counters, zoom buttons, close buttons) and customize padding sizes directly from their `config.json` via the `ipp.lightbox.options` object

In my case i would like to see image in full height wihout black gaps from top and bottom, and see counter state with progress:

<img width="2402" height="1223" alt="image" src="https://github.com/user-attachments/assets/19e14779-d4ff-4282-96a2-8f13b75fd078" />
