### PR TITLE
Fix download handling so that individual downloads can be allowed

### DIFF
--- a/app/src/gallery/builder.ts
+++ b/app/src/gallery/builder.ts
@@ -8,7 +8,7 @@ import {
 import { Response } from 'express-serve-static-core'
 import { AssetType, ImageSize, SharedLink } from '../types'
 import { getConfigOption } from '../config/access'
-import { canDownload, title } from '../share'
+import { canDownloadAll, title } from '../share'
 import { toString } from '../utils/text'
 import { h } from 'preact'
 import { renderPage } from '../view/render'
@@ -109,7 +109,7 @@ export async function gallery (res: Response, share: SharedLink, openItem?: numb
     }
   }))
 
-  const downloadAllowed = canDownload(share)
+  const downloadAllAllowed = canDownloadAll(share)
   // Prefer the album's owner-chosen cover for og:image; fall back to first
   // item if the cover asset has been filtered out (e.g. trashed).
   const coverId = share.album?.albumThumbnailAssetId
@@ -126,13 +126,12 @@ export async function gallery (res: Response, share: SharedLink, openItem?: numb
     description: getConfigOption('ipp.gallery.showDescription', false) ? description(share) : '',
     publicBaseUrl: toString(publicBaseUrl),
     path: '/share/' + share.key,
-    showDownload: downloadAllowed,
+    showDownload: downloadAllAllowed,
     showTitle: !!getConfigOption('ipp.gallery.showTitle', true),
     openItem,
     ogImageItem,
     lightboxConfig: {
-      // Show download button only if downloading is allowed AND configured.
-      showDownload: downloadAllowed && !!getConfigOption('ipp.lightbox.showDownload', true),
+      showDownload: !!getConfigOption('ipp.lightbox.showDownload', true),
       showArrows: !!getConfigOption('ipp.lightbox.showArrows', true),
       mobileArrows: !!getConfigOption('ipp.lightbox.mobileArrows', false),
       autoPlayVideos: !!getConfigOption('ipp.lightbox.autoPlayVideos', false),

--- a/app/src/immich.ts
+++ b/app/src/immich.ts
@@ -12,7 +12,7 @@ import {
 import dayjs from 'dayjs'
 import { getConfigOption } from './config/access'
 import { addResponseHeaders } from './http'
-import { canDownload } from './share'
+import { canDownloadAll } from './share'
 import { log } from './utils/log'
 import { assetBuffer } from './stream/asset'
 import { downloadAll } from './stream/download'
@@ -153,7 +153,7 @@ export async function handleShareRequest (req: IncomingShareRequest, res: Respon
 
   // Everything is ok - output the shared link data
 
-  if (req.mode === 'download' && canDownload(link)) {
+  if (req.mode === 'download' && canDownloadAll(link)) {
     // Download all assets as a zip file
     await downloadAll(res, link)
   } else if (link.assets.length === 1) {

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -20,7 +20,7 @@ import { Asset, AssetType, ImageSize, KeyType } from './types'
 import { getConfigOption } from './config/access'
 import { loadConfig } from './config/loader'
 import { addResponseHeaders } from './http'
-import { canDownload } from './share'
+import { canDownloadAll } from './share'
 import { toString } from './utils/text'
 import { decrypt, encrypt } from './encrypt'
 import { respondToInvalidRequest } from './invalidRequestHandler'
@@ -157,7 +157,7 @@ app.post('/:shareType(share|s)/:key/download', decodeCookie, async (req, res) =>
     respondToInvalidRequest(res, 401, 'Password required')
     return
   }
-  if (!canDownload(result.link)) {
+  if (!canDownloadAll(result.link)) {
     respondToInvalidRequest(res, 403, 'Downloads disabled for this share')
     return
   }

--- a/app/src/share.ts
+++ b/app/src/share.ts
@@ -16,7 +16,7 @@ export function title (share: SharedLink): string {
  * config controls the policy: disabled, follow the per-share Immich setting,
  * or always allowed.
  */
-export function canDownload (share: SharedLink): boolean {
+export function canDownloadAll (share: SharedLink): boolean {
   const allowDownloadConfig = getConfigOption('ipp.allowDownloadAll', 0) as DownloadAll
   if (!allowDownloadConfig) {
     // Downloading is disabled in config.json


### PR DESCRIPTION
This is a potential fix to the issue here: https://github.com/alangrainger/immich-public-proxy/issues/254

This is just one option, but I think maybe there's just some clarity around the "allowDownloadAll" that might also help.  Right now, it's tied together to the "showDownload" functionality, but because "allowDownloadAll" defaults to disabled, "showDownloads" default of true is negated.

I think there are a couple possible ways to address this.

1. Have 3 settings: One to manage download permissions globally (i.e. can anyone download anything), and then have individual settings as to whether the download link is shown (i.e. showDownloadAll, showDownloadLightbox, or just a broader showDownloadLinks for both)
2. Just have 2 settings to manage the permissions of those independently (i.e. allowDownloadAll, allowDownloadLightbox) which also mandate whether the option is shown.
3. Keep things the way they are, but ensure that documentation is clear that "allowDownloadAll" controls permissions for all downloads and enables the Download All button in the gallery, where as "showDownload" only controls the button visibility in the lightbox.  This has a downside that users can't disable all downloads, while still allowing individual downloads (not sure if that matters).

This PR takes option 2, where these flags give granular control over the download options, and controls the view as well.  I tried to do a quick rename as well to clarify that intent.

I haven't contributed here before, so please feel free to totally ignore this, or let me know if there's anything else you'd need.

Thanks for all the work on this!