### PR TITLE
feat(#153): serve single video shares as direct links

### DIFF
--- a/app/src/immich.ts
+++ b/app/src/immich.ts
@@ -201,8 +201,8 @@ export async function handleShareRequest (req: IncomingShareRequest, res: Respon
     // This is an individual item (not a gallery)
     log('Serving link ' + req.key)
     const asset = link.assets[0]
-    if (asset.type === AssetType.image && !getConfigOption('ipp.gallery.singleImage') && !req.password) {
-      // For photos, output the image directly unless configured to show a gallery,
+    if ((asset.type === AssetType.image || asset.type === AssetType.video) && !getConfigOption('ipp.gallery.singleImage') && !req.password) {
+      // For photos and videos, output them directly unless configured to show a gallery,
       // or unless it's a password-protected link
       await assetBuffer(req, res, link.assets[0], ImageSize.preview)
     } else {


### PR DESCRIPTION
Fixes #153 

Serve single-video shares as direct links, matching existing behavior for single images.

@alangrainger If you approve of the idea behind this PR, I'd be happy to update the PR based on your input on how to control direct link behavior for videos:

Should I:
- Rename `ipp.gallery.singleImage` to `singleAsset` (with a migration shim for backward compat)
- Or, introduce a separate `ipp.gallery.singleVideo` flag for independent control?
