### PR TITLE
Date grouping: follow the album's sort order instead of forcing newest-first

### DIFF
--- a/app/src/gallery/builder.ts
+++ b/app/src/gallery/builder.ts
@@ -28,13 +28,17 @@ export async function gallery (res: Response, share: SharedLink, openItem?: numb
   // You can specify this in your docker-compose file via the PUBLIC_BASE_URL env var.
   const publicBaseUrl = process.env.PUBLIC_BASE_URL || (res.req.protocol + '://' + res.req.headers.host)
 
-  // Date grouping needs chronological order; sort newest-first when enabled
-  // (overrides any album.order the upstream applied). Sort by the same local
-  // timestamp the grouping buckets on, so buckets stay contiguous / ordered.
+  // Date grouping needs chronological order; follow the album's own sort
+  // direction, defaulting to newest-first when it has none (individual shares).
+  // Sort by the same local timestamp the grouping buckets on, so buckets stay
+  // contiguous / ordered.
   const groupByDate = groupByDateMode()
   if (groupByDate) {
+    const ascending = share.album?.order === 'asc'
     const sortKey = (a: typeof share.assets[number]) => a.localDateTime || a.fileCreatedAt || ''
-    share.assets.sort((a, b) => sortKey(b).localeCompare(sortKey(a)))
+    share.assets.sort((a, b) => ascending
+      ? sortKey(a).localeCompare(sortKey(b))
+      : sortKey(b).localeCompare(sortKey(a)))
   }
 
   // Metadata display flags. Read once here and forwarded to the client via

--- a/docs/config/gallery.md
+++ b/docs/config/gallery.md
@@ -75,7 +75,7 @@ Group the gallery's thumbnails by date, with a header above each group.
 - `true` / `"month"` - month headers like "December 2024".
 - `"day"` - day headers like "25 December 2024".
 
-Grouping uses each photo's local "taken" date (matching Immich's own timeline), and sorts photos newest-first. Items missing a creation date end up under an "Undated" bucket at the end (or render without any header when the whole gallery is undated).
+Grouping uses each photo's local "taken" date (matching Immich's own timeline). Photos follow the album's own sort order from Immich - "Oldest first" puts the earliest group at the top, "Newest first" the most recent - and default to newest-first for shares with no album order. Items missing a creation date end up under an "Undated" bucket at the end (or render without any header when the whole gallery is undated).
 
 > [!IMPORTANT]
 > Requires **"Show metadata"** to be enabled on the share in Immich. When that's off, Immich strips creation dates from the assets it returns to IPP, so grouping won't work.


### PR DESCRIPTION
Fixes #271

### Problem

When `ipp.gallery.groupByDate` is enabled, the gallery always renders newest-first, ignoring the shared album's own sort order. An album set to **Oldest first** in Immich still shows the most-recent group at the top.

`immich.ts` already applies `link.album.order` (asc/desc), but the grouping sort in `gallery/builder.ts` then re-sorts unconditionally descending, discarding it. With grouping off the album order is respected, so this only affects the grouped view.

### Fix

Branch the grouping sort on `share.album?.order`: `asc` sorts ascending, anything else keeps the current descending default (unchanged for individual shares and albums with no order set). The client grouper preserves item order, so both the group order and the order within each group follow.

Also updates the `groupByDate` docs, which stated that photos are sorted newest-first.

### How to exercise

Set an album to **Oldest first** in Immich, share it, and set `groupByDate: "day"` - the earliest day group is now at the top with photos ascending inside each day. Switching the album to **Newest first** reverses it.

`npm run build`, `npm test` (112 passing) and `npx eslint src/` are all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date-grouped galleries now respect the album’s selected ascending or descending sort order.
  * Individual shares continue to default to newest-first ordering.

* **Documentation**
  * Clarified photo grouping, sorting, and handling of undated galleries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->