### PR TITLE
Fix exif info display resolution orientation

### DIFF
--- a/app/src/client/sidebar.ts
+++ b/app/src/client/sidebar.ts
@@ -383,11 +383,11 @@ function formatDate (iso: string): string {
   }
 }
 
-function formatBytes (bytes: number): string {
+export function formatBytes (bytes: number): string {
   if (bytes < 1024) return bytes + ' B'
   const kb = bytes / 1024
-  if (kb < 1024) return kb.toFixed(1) + ' KB'
+  if (kb < 1024) return kb.toFixed(1) + ' KiB'
   const mb = kb / 1024
-  if (mb < 1024) return mb.toFixed(1) + ' MB'
-  return (mb / 1024).toFixed(2) + ' GB'
+  if (mb < 1024) return mb.toFixed(1) + ' MiB'
+  return (mb / 1024).toFixed(2) + ' GiB'
 }

--- a/app/src/gallery/exif.ts
+++ b/app/src/gallery/exif.ts
@@ -62,6 +62,9 @@ const EXIF_RULES: FieldRule[] = [
       if (info.exifImageWidth && info.exifImageHeight) {
         out.width = info.exifImageWidth
         out.height = info.exifImageHeight
+        if (info.orientation && ['5', '6', '7', '8'].includes(info.orientation)) {
+          [out.width, out.height] = [out.height, out.width]
+        }
       }
     }
   },

--- a/app/tests/assetMetadata.test.ts
+++ b/app/tests/assetMetadata.test.ts
@@ -55,6 +55,19 @@ describe('buildAssetMetadata', () => {
     expect(meta.exif?.city).toBeUndefined()
   })
 
+  it('reports dimensions in display orientation', () => {
+    setConfig({ ipp: { showMetadata: { exif: { dimensions: true } } } })
+    const photo = asset()
+    photo.exifInfo!.exifImageWidth = 4000
+    photo.exifInfo!.exifImageHeight = 3000
+    photo.exifInfo!.orientation = '6'
+
+    expect(buildAssetMetadata(photo, share()).exif).toMatchObject({
+      width: 3000,
+      height: 4000
+    })
+  })
+
   it('returns description when a description surface is enabled', () => {
     setConfig({ ipp: { showMetadata: { description: { sidebar: true } } } })
     const meta = buildAssetMetadata(asset(), share())

--- a/app/tests/sidebarFileMetadata.test.ts
+++ b/app/tests/sidebarFileMetadata.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { formatBytes } from '../src/client/sidebar'
+
+describe('sidebar file metadata formatting', () => {
+  it('uses binary unit labels for binary calculations', () => {
+    expect(formatBytes(1023)).toBe('1023 B')
+    expect(formatBytes(1024)).toBe('1.0 KiB')
+    expect(formatBytes(3_500_000)).toBe('3.3 MiB')
+    expect(formatBytes(3 * 1024 ** 3)).toBe('3.00 GiB')
+  })
+})


### PR DESCRIPTION
Exif info display doesn't account for orientation, so this fixes that

I'm looking at a **vertical** picture and the result you see now is this as expected:

<img width="261" height="70" alt="image" src="https://github.com/user-attachments/assets/8c3cf738-3953-4d0a-8f57-6331b3bad0bd" />

As compared to the current version before this PR:

<img width="252" height="67" alt="image" src="https://github.com/user-attachments/assets/7c7048f0-3ba1-46c0-9444-2d98465e9a3a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected image dimension display for photos with rotated EXIF orientations.
  - Updated file-size labels to use binary units: KiB, MiB, and GiB.

- **Tests**
  - Added coverage for orientation-aware image dimensions.
  - Added coverage for file-size formatting, boundaries, rounding, and precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->