### PR TITLE
UX improvement - Keep loaded gallery thumbnails mounted to stop scroll-back flicker

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "immich-public-proxy",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "immich-public-proxy",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immich-public-proxy",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "scripts": {
     "dev": "concurrently -n server,client -c blue,green \"tsx watch src/index.ts\" \"tsc -w -p tsconfig.client.json\"",
     "build": "tsc && tsc -p tsconfig.client.json",

--- a/app/src/client/state.ts
+++ b/app/src/client/state.ts
@@ -15,6 +15,13 @@ export const MOBILE_COLS = 3
 export const IMAGE_LOAD_MARGIN_PX = 300
 export const SCROLL_SETTLE_MS = 100
 export const BUFFER_VIEWPORTS = 1
+// Upper bound on how many already-loaded tiles we keep permanently mounted
+// (see state.stickyTiles). ~1500 covers dozens of screens of scroll-back so
+// revisiting recently-seen thumbnails never flickers, while capping retained
+// DOM / decoded-image memory so a 100k-photo album can't grow unbounded as
+// the user scrolls. Least-recently-visible tiles past this count fall back to
+// normal virtualisation and re-pin if scrolled back to.
+export const STICKY_TILE_LIMIT = 1500
 // Height reserved for each month header (must agree with .group-header CSS)
 export const HEADER_HEIGHT = 48
 // Vertical gap between groups
@@ -73,6 +80,16 @@ export const state = {
   lastContainerW: 0,
   renderedTiles: new Map<number, HTMLAnchorElement>(),
   renderedHeaders: new Map<string, HTMLElement>(),
+  // Tile indices whose <img> has fired `load` at least once. While an index
+  // is in this set virtualize() never removes its tile, so scrolling back to
+  // an already-seen thumbnail shows the cached image with no placeholder /
+  // fade-in flicker. Insertion order is maintained as most-recently-visible-
+  // last and the set is trimmed to STICKY_TILE_LIMIT each virtualize() pass,
+  // so a huge album can't accumulate unbounded mounted DOM. Tiles that have
+  // not loaded yet get the normal lazy create / remove treatment, so large
+  // albums still lazy-load on first scroll-into-view. Cleared on a layout
+  // recompute (see computeLayoutAndRender) because tile geometry changes.
+  stickyTiles: new Set<number>(),
   // Selection mode (mode-toggle UX: hidden checkmarks until activated)
   selectMode: false,
   selected: new Set<string>(),

--- a/app/src/client/tiles.ts
+++ b/app/src/client/tiles.ts
@@ -78,7 +78,11 @@ export function createTile (index: number): HTMLAnchorElement {
     // Pin this tile: once loaded it is never virtualised out again, so a
     // scroll back up reuses this exact <img> instead of rebuilding it in a
     // blank/placeholder state. See state.stickyTiles / virtualize().
-    state.stickyTiles.add(index)
+    // Guard: if this tile was virtualised out before its (in-flight) image
+    // finished, the load still fires on the now-detached <img>. Only pin the
+    // index while this <a> is still the live tile for it, so a stale request
+    // can't mark a not-yet-loaded replacement tile as sticky.
+    if (state.renderedTiles.get(index) === a) state.stickyTiles.add(index)
   }
   a.appendChild(img)
 

--- a/app/src/client/tiles.ts
+++ b/app/src/client/tiles.ts
@@ -73,7 +73,13 @@ export function createTile (index: number): HTMLAnchorElement {
   // `#gallery img.loaded` fades opacity from 0 to 1 so the thumbhash blurs
   // into the sharp image instead of snapping (and masks Chrome/Edge's brief
   // white flash between `img.src` being set and the bytes actually painting).
-  img.onload = () => img.classList.add('loaded')
+  img.onload = () => {
+    img.classList.add('loaded')
+    // Pin this tile: once loaded it is never virtualised out again, so a
+    // scroll back up reuses this exact <img> instead of rebuilding it in a
+    // blank/placeholder state. See state.stickyTiles / virtualize().
+    state.stickyTiles.add(index)
+  }
   a.appendChild(img)
 
   if (item.type === 'VIDEO') {

--- a/app/src/client/virtualisation.ts
+++ b/app/src/client/virtualisation.ts
@@ -7,6 +7,7 @@ import {
   IMAGE_LOAD_MARGIN_PX,
   SCROLL_SETTLE_MS,
   BUFFER_VIEWPORTS,
+  STICKY_TILE_LIMIT,
   type HeaderEntry
 } from './state.js'
 import { computeLayout } from './layout.js'
@@ -56,6 +57,26 @@ export function virtualize () {
     if (l.top > bottom) break
     neededTiles.add(l.index)
   }
+  // Sticky (already-loaded) tiles: keep them in the "needed" set so
+  // syncRendered never removes them and a scroll-back shows the cached image
+  // with no flicker. Bounded so a very large album can't grow unbounded DOM:
+  //  1. bump currently-visible sticky tiles to most-recently-used (set tail),
+  //  2. evict the oldest overflow that isn't on screen right now,
+  //  3. union whatever remains into neededTiles (all already rendered, so
+  //     this only blocks removal - it never triggers a re-create).
+  for (const index of neededTiles) {
+    if (state.stickyTiles.delete(index)) state.stickyTiles.add(index)
+  }
+  if (state.stickyTiles.size > STICKY_TILE_LIMIT) {
+    let overflow = state.stickyTiles.size - STICKY_TILE_LIMIT
+    for (const index of state.stickyTiles) {
+      if (overflow <= 0) break
+      if (neededTiles.has(index)) continue
+      state.stickyTiles.delete(index)
+      overflow--
+    }
+  }
+  for (const index of state.stickyTiles) neededTiles.add(index)
   syncRendered(neededTiles, state.renderedTiles, createTile)
 
   // Group headers (when grouping is enabled; headers is empty otherwise)
@@ -128,6 +149,11 @@ export function computeLayoutAndRender () {
   state.renderedTiles.clear()
   for (const [, el] of state.renderedHeaders) el.remove()
   state.renderedHeaders.clear()
+  // Tile positions/sizes have changed, so the old pinned <img> elements are
+  // gone. Drop the sticky set and let tiles re-pin themselves as they reload
+  // for the new layout - otherwise the virtualize() below would rebuild every
+  // previously-seen tile at once.
+  state.stickyTiles.clear()
 
   virtualize()
   loadVisibleTiles()
@@ -149,6 +175,9 @@ export function loadVisibleTiles () {
   for (const a of state.renderedTiles.values()) {
     const img = a.firstElementChild
     if (!(img instanceof HTMLImageElement)) continue
+    // Fast-path: a finished load with no parked data-src has nothing to
+    // toggle. Matters now that sticky tiles keep this map large.
+    if (img.complete && img.src && !img.dataset.src) continue
     const aTopInVp = containerTop + parseFloat(a.style.top || '0')
     const aHeight = parseFloat(a.style.height || '0')
     const isFar = aTopInVp + aHeight < -IMAGE_LOAD_MARGIN_PX ||


### PR DESCRIPTION
## Human written

Scrolling up and down on the gallery page unnecessarily replaces thumbnails that have already been downloaded by the browser with blurred placeholders, since only the currently visible images are rendered on screen.

This creates a poor user experience because users may see blurry loading thumbnails for already scrolled past images that have already been received and could be displayed immediately.

This PR addresses the issue by pinning already loaded thumbnails (upto last 1500) rendered, so scrolling back doesnt cause reloads and blurred placeholders while new thumbnails are still lazy loaded normally.

The PR was built with Claude and the resulting implementation was tested and verified.

## What
Loaded thumbnails no longer flicker back to a placeholder / fade-in when
scrolled off-screen and then back into view.

## Why
The gallery virtualiser (`app/src/client/virtualisation.ts`) removed a tile's
`<a>`/`<img>` from the DOM whenever it left the viewport ± 1-viewport buffer
and rebuilt it from scratch on re-entry. On the rebuild the `<img>` starts with
only `data-src` (no `src`) and no `.loaded` class, so the thumbhash blur shows
and the 0.25s opacity fade replays — even for small (~150 photo) albums where
Cache-Control means there's no real network fetch.

## How
- New bounded, LRU-ordered `state.stickyTiles` set of tile indices whose
  `<img>` has fired `load`. `virtualize()` unions it into `neededTiles` so
  `syncRendered` never unmounts a loaded tile.
- Not-yet-loaded tiles are untouched: they still create/remove on scroll and
  use the `data-src` → `src` lazy lifecycle, so large albums keep lazy-loading
  on first scroll-into-view.
- Trimmed to `STICKY_TILE_LIMIT` (1500) each pass — visible tiles bumped to
  most-recently-used, oldest off-screen overflow released back to normal
  virtualisation — so a 100k-photo album can't accumulate unbounded mounted
  DOM / retained image memory. Released tiles re-pin if revisited.
- `stickyTiles` cleared in `computeLayoutAndRender()` (tile geometry changes on
  a width/column change).
- Fast-path `continue` in `loadVisibleTiles()` for finished loads, since the
  rendered-tile map is now larger.

## Reviewer notes
- `BUFFER_VIEWPORTS` unchanged (still 1).
- Only trade-off vs. today: travel >1500 tiles away from a thumbnail and back
  and it does one re-load — same single flicker as current behaviour.
- No server-side changes; client TS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced image flicker when scrolling back through previously viewed gallery tiles.
  * Preserved loaded images during virtualized scrolling for smoother navigation.
  * Improved image loading efficiency by avoiding unnecessary reloads for already-loaded images.
  * Limited retained gallery tiles to maintain responsive performance during extended browsing.
  * Refreshed tile retention when the gallery layout changes to prevent stale content from appearing.
  * Prevented outdated image-loading events from incorrectly retaining tiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->